### PR TITLE
website: fix osbuild-composer 8 news

### DIFF
--- a/_collections/_news/2020-03-18-release-osbuild-composer-8.md
+++ b/_collections/_news/2020-03-18-release-osbuild-composer-8.md
@@ -2,8 +2,8 @@
 caption: "Release of osbuild-composer 8"
 author: "David Rheinsberg"
 ---
-We are happy to announce version 8 of *osbuild*, again one of our regular
-biweekly releases.
+We are happy to announce version 8 of *osbuild-composer*, again one of our
+regular biweekly releases.
 
 The biggest change is that we now use the `org.osbuild.rpm`
 stages, rather than `org.osbuild.dnf`. This makes the dependency resolution of


### PR DESCRIPTION
It mentioned `osbuild` instead of `osbuild-composer`.