### PR TITLE
home: show date in front of news items

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ To build the website from its sources, use:
 jekyll build
 ```
 
+To try it out locally, use:
+
+```sh
+jekyll serve
+```
+
 ### Repository:
 
  - **web**:   <https://github.com/osbuild/osbuild.github.io>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,11 +9,11 @@ layout: root
 <section class="pv2 ph5
                 bb b--light-gray">
   <article class="tj">
-    <span class="b">News #0:</span>
+    <span class="gray">{{ news0.date | date: "%B %e, %Y" }}</span>
     <a href="{{ news0.url | relative_url }}">{{ news0.caption }}</a>
   </article>
   <article class="tj">
-    <span class="b">News #1:</span>
+    <span class="gray">{{ news1.date | date: "%B %e, %Y" }}</span>
     <a href="{{ news1.url | relative_url }}">{{ news1.caption }}</a>
   </article>
 </section>


### PR DESCRIPTION
Drop the "News #X:" prefix. It should be fairly clear these are news.