### PR TITLE
documentation: update cockpit-composer url

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -24,7 +24,7 @@ respective user interface is the best source of help. Furthermore, the
 documentation of _OSBuild Composer_ (see below) will provide insights into the
 internals of the image building tools.
 
-* **Development**: [@GitHub](https://github.com/weldr/cockpit-composer)
+* **Development**: [@GitHub](https://github.com/osbuild/cockpit-composer)
 
 * **Packages**: The _Image Builder_ project is pre-packaged for the
   following distributions:


### PR DESCRIPTION
Cockpit-composer has moved from the weldr to the osbuild github organization so its url has changed. The link to cockpit-composer is updated.

This PR should not be merged until after cockpit-composer has moved to the osbuild organization.