### PR TITLE
ci: add jekyll test-run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+#
+# Repository Tests
+#
+# This workflow runs basic functionality tests on every branch and PR. It runs
+# `jekyll build` to verify the pages build correctly. Furthermore, it runs the
+# `htmlproofer` utility to verify HTML correctness as well as detect broken
+# links.
+#
+# This uses the `jekyll/jekyll` docker image to get access to the latest jekyll
+# releases. We cannot know the version used by GitHub, so we simply use the
+# latest stable release instead.
+#
+
+name: "Repository Tests"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: "Test-build jekyll pages"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Pull build environment"
+      run: docker pull jekyll/jekyll:stable
+    - name: "Clone local repository"
+      uses: actions/checkout@v2
+    - name: "Build jekyll pages"
+      run: |
+        docker run \
+          --env "JEKYLL_UID=$(id -u)" \
+          --env "JEKYLL_GID=$(id -u)" \
+          --rm \
+          --volume "${PWD}:/srv/jekyll" \
+          "jekyll/jekyll:stable" \
+          jekyll build
+    - name: "Verify generated HTML"
+      run: |
+        docker run \
+          --rm \
+          --volume "${PWD}:/srv/jekyll" \
+          "jekyll/jekyll:stable" \
+          /usr/gem/bin/htmlproofer --assume-extension "./_site"


### PR DESCRIPTION
Add a new workflow that runs jekyll on all branches and PRs. This
verifies the jekyll generation works, and thus serves as neat small CI
test for us.

We cannot reproduce the exact environment that github uses to generate
the pages. However, this at least verifies the latest stable jekyll
release works.

While at it, run htmlproofer as well, to verify links and html
validity.