### PR TITLE
ci: replace deprecated `::set-env` call

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -57,7 +57,7 @@ jobs:
           BASEURL="/${REPO}"
         fi
         echo "Base-url: ${BASEURL}"
-        echo "::set-env name=BASEURL::${BASEURL}"
+        echo "BASEURL=${BASEURL}" >>"${GITHUB_ENV}"
 
     #
     # Build pages


### PR DESCRIPTION
Replace `::set-env` with the official `$GITHUB_ENV` alternative.

The `::set-env` call has been deprecated by github, because it allows
arbitrary commands to modify the host environment by simply writing to
the output buffer:

    https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

While we are not susceptible to these attacks (we do not run sandboxed
commands), we want to switch away from the deprecated interface and
instead use the official replacement:

    https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

The difference is, this new method requires access to the host
file-system, and as such cannot be misused in sandboxed environments,
unless you grant the sandbox write-access to the host.

In our case, this should not make any visible difference, other than
removing the "deprecation" warnings on the website.