### PR TITLE
ci: avoid `master` for man-page imports

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -83,11 +83,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: osbuild/osbuild
-        # XXX: This should be:
-        #     ${{ steps.config.outputs.OSBUILD_VERSION }}
-        # However, we use `master` for now until we have a new release which
-        # includes the required Makefile, man-pages, and tooling.
-        ref: master
+        ref: ${{ steps.config.outputs.OSBUILD_VERSION }}
         path: osbuild
     - name: Clone osbuild-composer repository
       uses: actions/checkout@v2


### PR DESCRIPTION
We import man-pages from upstream osbuild and osbuild-composer projects.
We used `master` as target branch for `osbuild`, but always intended to
switch away from it and instead use the latest release (as we already do
for composer).

Switch over to using the latest release tag instead of `master`, so the
man-page imports work again.