### PR TITLE
index: minor content updates

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,10 +17,9 @@ that can be deployed as a hosted service.
 ## Development
 
 Join the development efforts of the open-source
-[osbuild project](https://github.com/osbuild) on GitHub. The project is in its
-early stages and under active development. Contributions of any form are
-welcome, including development efforts, testing, documentation, and general
-feedback.
+[osbuild project](https://github.com/osbuild) on GitHub. Contributions of any
+form are welcome, including development efforts, testing, documentation, and
+general feedback.
 
 The project is currently packaged for the following distributions:
 

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ The project is currently packaged for the following distributions:
 ## Maintenance
 
 **OSBuild** is released under the terms of the *Apache Software License 2.0,
-Copyright © 2019-2020 Red Hat, Inc.*.
+Copyright © 2019-2021 Red Hat, Inc.*.
 
  * **License**: *Apache Software License 2.0*
  * **Contact**: [@GitHub](https://github.com/osbuild)


### PR DESCRIPTION
2 updates to the index/landing page of osbuild.org. See each one for details.