### PR TITLE
ci: limit concurrency of resource import

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -20,6 +20,8 @@ on:
   schedule:
   - cron:  '0 0 * * *'
 
+concurrency: wf-import
+
 jobs:
   import:
     name: Import Resources to be Published


### PR DESCRIPTION
Use the new `concurrency` flag of github-actions [1] to prevent parallel
runs. Define the concurrency-group as `wf-import` for all runs of this
workflow, so only a single run will be executed at a time.

[1] https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency