### PR TITLE
ci: replace `::set-output` with `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -67,8 +67,8 @@ jobs:
       run: |
         OSBUILD_VERSION=$(curl --silent "https://api.github.com/repos/osbuild/osbuild/releases/latest" | jq -r .tag_name)
         OSBUILD_COMPOSER_VERSION=$(curl --silent "https://api.github.com/repos/osbuild/osbuild-composer/releases/latest" | jq -r .tag_name)
-        echo "::set-output name=OSBUILD_VERSION::${OSBUILD_VERSION}"
-        echo "::set-output name=OSBUILD_COMPOSER_VERSION::${OSBUILD_COMPOSER_VERSION}"
+        echo "OSBUILD_VERSION=${OSBUILD_VERSION}" >>$GITHUB_OUTPUT
+        echo "OSBUILD_COMPOSER_VERSION=${OSBUILD_COMPOSER_VERSION}" >>$GITHUB_OUTPUT
 
     #
     # Setup Checkout


### PR DESCRIPTION
The `::set-output` command is deprecated [1] and will be dropped in 2023. Use the suggested replacement by writing into `$GITHUB_OUTPUT`.

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/