### PR TITLE
navigation: remove news link

### DIFF
--- a/_layouts/root.html
+++ b/_layouts/root.html
@@ -19,8 +19,6 @@
       <nav class="lh-copy">
         <a href="{{ '' | relative_url }}/"
            class="mh2 link blue hover-mid-gray">Home</a>
-        <a href="{{ 'news' | relative_url }}/"
-           class="mh2 link blue hover-mid-gray">News</a>
         <a href="{{ 'documentation' | relative_url }}/"
            class="mh2 link blue hover-mid-gray">Documentation</a>
 {% if site.media.github %}


### PR DESCRIPTION
The news section is very sparsely updated. We can keep all the content around but not have the `news` link in the main navigation anymore to avoid looking inactive.