### PR TITLE
docs: Link directly to guides

### DIFF
--- a/_layouts/root.html
+++ b/_layouts/root.html
@@ -21,7 +21,7 @@
            class="mh2 link blue hover-mid-gray">Home</a>
         <a href="{{ 'news' | relative_url }}/"
            class="mh2 link blue hover-mid-gray">News</a>
-        <a href="{{ 'documentation' | relative_url }}/"
+        <a href="https://www.osbuild.org/guides/introduction.html"
            class="mh2 link blue hover-mid-gray">Documentation</a>
 {% if site.media.github %}
         <a href="https://github.com/{{ site.media.github }}"


### PR DESCRIPTION
Our static documentation is duplicated in our guides, so let's link to those directly instead.